### PR TITLE
Remove create function

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -2,6 +2,7 @@
 Contributors: TigrouMeow, Okonomiyaki3000
 Tags: category, permalink, woocommerce
 Requires at least: 3.5
+Requires PHP: 5.3
 Tested up to: 4.9
 Stable tag: 3.3.0
 
@@ -43,6 +44,9 @@ Nothing to be careful about here, just update :)
 2. Check your permalinks in the posts list. If a heart is present, it means a category (or taxonomy) has been chosen.
 
 == Changelog ==
+
+= dev-master =
+* Compatibility with PHP 7.2 by removing create_function calls.
 
 = 3.3.0 =
 * Everything is released for free.

--- a/wpcp_admin.php
+++ b/wpcp_admin.php
@@ -78,15 +78,19 @@ class MWCP_Admin extends MeowApps_Admin {
 
 									$fields = array();
 					        $post_types = MWCPPost::post_types();
-					        $map = create_function( '$a', 'return $a->query_var;' );
 									foreach ( $post_types as $type => $post_info )
 					        {
 										echo "<h4>$post_info->label</h4>";
 
-				            $taxa = MWCPPost::taxonomies( $type );
-				            if ( empty( $taxa ) )
-				                continue;
-				            $query_vars = array_map( $map, $taxa );
+							$taxa = MWCPPost::taxonomies( $type );
+							if ( empty( $taxa ) )
+								continue;
+							$query_vars = array_map(
+								function( $a ) {
+									return $a->query_var;
+								},
+								$taxa
+							);
 										global $wp_rewrite;
 						        $post_link = $wp_rewrite->get_extra_permastruct( $type );
 				            echo __( '<small>Permalink: ' ) . $post_link . '<br>' .

--- a/wpcp_post.php
+++ b/wpcp_post.php
@@ -157,7 +157,12 @@ abstract class MWCPPost
         if ( !is_array( $taxa ) )
         {
             $taxa = get_taxonomies( array( 'public' => 1, 'hierarchical' => 1 ), 'objects' );
-            $taxa = array_filter( $taxa, create_function( '$a',  'return !!$a->rewrite;' ) );
+            $taxa = array_filter(
+                $taxa,
+                function( $a ) {
+                    return !!$a->rewrite;
+                }
+            );
         }
 
         $return = array();


### PR DESCRIPTION
closes #2

PHP 7.2 deprecates `create_function()`. In order to stay compatible, this PR removes the `create_function()` calls and uses anonymous functions instead.

Using anonymous functions comes with a downside: They have been introduced in PHP 5.3. So, if wp-category-permalink wants to stay compatible with PHP 5.2, it would require a rewrite, which I could provide if wished for.

Thank you for considering this PR.