### PR TITLE
wp-category-permalink.js: allow user to remove a previously selected …

### DIFF
--- a/wp-category-permalink.js
+++ b/wp-category-permalink.js
@@ -25,17 +25,21 @@
       this.find('.taxa-value-selector').click(function (event) {
         event.preventDefault();
         console.debug(event);
+        if ($(this).parents('.selectit').css('fontWeight') == '700') {
 
-        if ($(this).css('fontWeight') == 'bold') {
-          $('.permalink-taxa', me).val('');
-          $(this).css('fontWeight', 'normal');
+            $('.permalink-taxa', me).val('');
+            $(this).parents('.selectit').css('fontWeight', 'normal');
+
+        } else {
+
+            me.find('.selectit').css('fontWeight', '');
+            $(this).parents('.selectit').css('fontWeight', 'bold');
+            $(this).parents('.selectit').find('input').prop('checked', true);
+            var val = $(this).prev().attr('value');
+            $('.permalink-taxa', me).val(val);
+
         }
 
-        me.find('.selectit').css('fontWeight', '');
-        $(this).parents('.selectit').css('fontWeight', 'bold');
-        $(this).parents('.selectit').find('input').prop('checked', true);
-        var val = $(this).prev().attr('value');
-        $('.permalink-taxa', me).val(val);
       });
 
       var taxonomy = $(this).data('taxonomy');

--- a/wp-category-permalink.php
+++ b/wp-category-permalink.php
@@ -3,7 +3,7 @@
 Plugin Name: WP Category Permalink
 Plugin URI: https://meowapps.com
 Description: Allows manual selection of a 'main' category for each post for better permalinks and SEO.
-Version: 3.4.0
+Version: 3.5.0
 Author: Jordy Meow
 Author URI: https://meowapps.com
 

--- a/wpcp_ui.php
+++ b/wpcp_ui.php
@@ -21,7 +21,7 @@ abstract class MWCPUI
     public static function enqueue_script()
     {
         $url = plugins_url('/wp-category-permalink.js', dirname(__FILE__) . '/../' );
-        wp_enqueue_script( 'wp-category-permalink.js', $url, array( 'jquery' ), '3.2.3', false );
+        wp_enqueue_script( 'wp-category-permalink.js', $url, array( 'jquery' ), '3.3.5', false );
     }
 
     public static function post_js()


### PR DESCRIPTION
I changed how wp-category-permalink.js handles clicks to `this.find('.taxa-value-selector')`
Now, if user clicks a previously selected category-permalink the value of hidden input field `$('.permalink-taxa', me)` get cleared-out.
This solves a bug when user unselects a category which was set as category-permalink, saves the form and the category is still selected making  it impossible to remove it.