### PR TITLE
Post type filter

### DIFF
--- a/wp-category-permalink.js
+++ b/wp-category-permalink.js
@@ -25,17 +25,21 @@
       this.find('.taxa-value-selector').click(function (event) {
         event.preventDefault();
         console.debug(event);
+        if ($(this).parents('.selectit').css('fontWeight') == '700') {
 
-        if ($(this).css('fontWeight') == 'bold') {
-          $('.permalink-taxa', me).val('');
-          $(this).css('fontWeight', 'normal');
+            $('.permalink-taxa', me).val('');
+            $(this).parents('.selectit').css('fontWeight', 'normal');
+
+        } else {
+
+            me.find('.selectit').css('fontWeight', '');
+            $(this).parents('.selectit').css('fontWeight', 'bold');
+            $(this).parents('.selectit').find('input').prop('checked', true);
+            var val = $(this).prev().attr('value');
+            $('.permalink-taxa', me).val(val);
+
         }
 
-        me.find('.selectit').css('fontWeight', '');
-        $(this).parents('.selectit').css('fontWeight', 'bold');
-        $(this).parents('.selectit').find('input').prop('checked', true);
-        var val = $(this).prev().attr('value');
-        $('.permalink-taxa', me).val(val);
       });
 
       var taxonomy = $(this).data('taxonomy');

--- a/wp-category-permalink.php
+++ b/wp-category-permalink.php
@@ -3,7 +3,7 @@
 Plugin Name: WP Category Permalink
 Plugin URI: https://meowapps.com
 Description: Allows manual selection of a 'main' category for each post for better permalinks and SEO.
-Version: 3.4.0
+Version: 3.5.0
 Author: Jordy Meow
 Author URI: https://meowapps.com
 

--- a/wp-category-permalink.php
+++ b/wp-category-permalink.php
@@ -3,7 +3,7 @@
 Plugin Name: WP Category Permalink
 Plugin URI: https://meowapps.com
 Description: Allows manual selection of a 'main' category for each post for better permalinks and SEO.
-Version: 3.5.0
+Version: 3.6.0
 Author: Jordy Meow
 Author URI: https://meowapps.com
 

--- a/wpcp_post.php
+++ b/wpcp_post.php
@@ -145,6 +145,15 @@ abstract class MWCPPost
             {
                 $post_types = array();
             }
+
+	        /**
+	         * Filters the post_types enabled for permalink overrides
+	         *
+	         * @since 3.6.0
+	         *
+	         * @param array $post_types the allowed post_types
+	         */
+            $post_types = apply_filters('wp_category_permalink_post_types',$post_types);
         }
 
         return $post_types;

--- a/wpcp_ui.php
+++ b/wpcp_ui.php
@@ -21,7 +21,7 @@ abstract class MWCPUI
     public static function enqueue_script()
     {
         $url = plugins_url('/wp-category-permalink.js', dirname(__FILE__) . '/../' );
-        wp_enqueue_script( 'wp-category-permalink.js', $url, array( 'jquery' ), '3.2.3', false );
+        wp_enqueue_script( 'wp-category-permalink.js', $url, array( 'jquery' ), '3.3.5', false );
     }
 
     public static function post_js()


### PR DESCRIPTION
I needed to filter post_types enabled for permalink overrides; I had a bunch of post_types without taxonomies registered to them and with a permastruct without a %taxonomy% placeholder.
These post_types had empty GUID and broken preview permalink caused by MWCPPost()::post_type_link() hooked to filter post_type_link

I solved the problem implementing a filter hook "wp_category_permalink_post_types" to MWCPPost()::post_types() affecting the valued returned by the method.
